### PR TITLE
Correção de urls de consulta distribuição e consulta cadastro

### DIFF
--- a/pysped/nfe/processador_nfe.py
+++ b/pysped/nfe/processador_nfe.py
@@ -251,6 +251,8 @@ class ProcessadorNFe(object):
             if somente_ambiente_nacional:
                 self._servidor = webservices_3.AN[ambiente]['servidor']
                 self._url      = webservices_3.AN[ambiente][servico]
+                if ambiente == 1 and servico == WS_DFE_DISTRIBUICAO:
+                    self._servidor = 'www1.nfe.fazenda.gov.br'
 
             elif servico == WS_NFE_DOWNLOAD:
                 self._servidor = webservices_3.SVAN[ambiente]['servidor']
@@ -271,13 +273,12 @@ class ProcessadorNFe(object):
                     ws_a_usar = webservices_3.ESTADO_WS[self.estado]
 
                 self._servidor = ws_a_usar[ambiente]['servidor']
-                self._url      = ws_a_usar[ambiente][servico]
-                
-                if ambiente == 1 and servico == WS_DFE_DISTRIBUICAO:
-                    self._servidor = 'www1.nfe.fazenda.gov.br'
+                self._url      = ws_a_usar[ambiente][servico]                
                 
                 if self.estado == 'RS' and servico == WS_NFE_CONSULTA_CADASTRO:
                     self._servidor = 'sef.sefaz.rs.gov.br'
+                if (self.estado == 'SC' or self.estado == 'RJ') and servico == WS_NFE_CONSULTA_CADASTRO:
+                    self._servidor = 'cad.svrs.rs.gov.br'
 
         self._soap_envio.webservice = metodo_ws[servico]['webservice']
         self._soap_envio.metodo     = metodo_ws[servico]['metodo']

--- a/pysped/nfe/webservices_3.py
+++ b/pysped/nfe/webservices_3.py
@@ -283,28 +283,28 @@ UFBA = {
     }
 }
 
-#UFCE = {
-    #NFE_AMBIENTE_PRODUCAO: {
-        #'servidor'              : 'nfe.sefaz.ce.gov.br',
-        #WS_NFE_AUTORIZACAO       : 'nfe2/services/NfeRecepcao2',
-        #WS_NFE_CONSULTA_AUTORIZACAO  : 'nfe2/services/NfeRetRecepcao2',
-        #WS_NFE_INUTILIZACAO     : 'nfe2/services/NfeInutilizacao2',
-        #WS_NFE_CONSULTA         : 'nfe2/services/NfeConsulta2',
-        #WS_NFE_SITUACAO         : 'nfe2/services/NfeStatusServico2',
-        #WS_NFE_CONSULTA_CADASTRO: 'nfe2/services/CadConsultaCadastro2',
-        #WS_NFE_RECEPCAO_EVENTO  : 'nfe2/services/RecepcaoEvento',
-    #},
-    #NFE_AMBIENTE_HOMOLOGACAO: {
-        #'servidor'              : 'nfeh.sefaz.ce.gov.br',
-        #WS_NFE_AUTORIZACAO       : 'nfe2/services/NfeRecepcao2',
-        #WS_NFE_CONSULTA_AUTORIZACAO  : 'nfe2/services/NfeRetRecepcao2',
-        #WS_NFE_INUTILIZACAO     : 'nfe2/services/NfeInutilizacao2',
-        #WS_NFE_CONSULTA         : 'nfe2/services/NfeConsulta2',
-        #WS_NFE_SITUACAO         : 'nfe2/services/NfeStatusServico2',
-        #WS_NFE_CONSULTA_CADASTRO: 'nfe2/services/CadConsultaCadastro2',
-        #WS_NFE_RECEPCAO_EVENTO  : 'nfe2/services/RecepcaoEvento',
-    #}
-#}
+UFCE = {
+    NFE_AMBIENTE_PRODUCAO: {
+        'servidor'              : 'nfe.sefaz.ce.gov.br',
+        WS_NFE_AUTORIZACAO       : 'nfe2/services/NfeRecepcao2',
+        WS_NFE_CONSULTA_AUTORIZACAO  : 'nfe2/services/NfeRetRecepcao2',
+        WS_NFE_INUTILIZACAO     : 'nfe2/services/NfeInutilizacao2',
+        WS_NFE_CONSULTA         : 'nfe2/services/NfeConsulta2',
+        WS_NFE_SITUACAO         : 'nfe2/services/NfeStatusServico2',
+        WS_NFE_CONSULTA_CADASTRO: 'nfe2/services/CadConsultaCadastro2',
+        WS_NFE_RECEPCAO_EVENTO  : 'nfe2/services/RecepcaoEvento',
+    },
+    NFE_AMBIENTE_HOMOLOGACAO: {
+        'servidor'              : 'nfeh.sefaz.ce.gov.br',
+        WS_NFE_AUTORIZACAO       : 'nfe2/services/NfeRecepcao2',
+        WS_NFE_CONSULTA_AUTORIZACAO  : 'nfe2/services/NfeRetRecepcao2',
+        WS_NFE_INUTILIZACAO     : 'nfe2/services/NfeInutilizacao2',
+        WS_NFE_CONSULTA         : 'nfe2/services/NfeConsulta2',
+        WS_NFE_SITUACAO         : 'nfe2/services/NfeStatusServico2',
+        WS_NFE_CONSULTA_CADASTRO: 'nfe2/services/CadConsultaCadastro2',
+        WS_NFE_RECEPCAO_EVENTO  : 'nfe2/services/RecepcaoEvento',
+    }
+}
 
 
 UFGO = {
@@ -528,7 +528,7 @@ ESTADO_WS = {
     'AM': UFAM,
     'AP': SVRS,
     'BA': UFBA,
-    #'CE': UFCE,
+    'CE': UFCE,
     'DF': SVRS,
     'ES': SVRS,
     'GO': UFGO,

--- a/pysped/xml_sped/base.py
+++ b/pysped/xml_sped/base.py
@@ -429,7 +429,7 @@ class TagData(TagCaracter):
     def set_valor(self, novo_valor):
         if isinstance(novo_valor, basestring):
             if novo_valor:
-                novo_valor = datetime.strptime(novo_valor, '%Y-%m-%d')
+                novo_valor = datetime.strptime(novo_valor[:10], '%Y-%m-%d')
             else:
                 novo_valor = None
 


### PR DESCRIPTION
Separação do PR #4 
- Webservice do PR enviava data em formato errado, modificado para pegar apenas 10 primeiros caracteres da data.
- Correção de url do serviço de distribuição.
- Correção da url de consulta cadastro de SC e RJ.
