### PR TITLE
[FIX] Versão do SSL no processador_nfe

### DIFF
--- a/pysped/nfe/processador_nfe.py
+++ b/pysped/nfe/processador_nfe.py
@@ -164,7 +164,7 @@ class ConexaoHTTPS(HTTPSConnection):
         if self._tunnel_host:
             self.sock = sock
             self._tunnel()
-        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_SSLv3, do_handshake_on_connect=False)
+        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_TLSv1, do_handshake_on_connect=False)
 
 
 class ProcessadorNFe(object):


### PR DESCRIPTION
[FIX] ssl version atualizado porque sslv3 foi desativada.

Correção do PR: https://github.com/odoo-brazil/PySPED/pull/21
